### PR TITLE
fix: 修复 Windows 同步 Kiro 时的 UTF-8 编码问题

### DIFF
--- a/popup/popup.js
+++ b/popup/popup.js
@@ -327,19 +327,22 @@ async function syncToKiro(id) {
 
     if (os === 'windows') {
       // Windows PowerShell 命令
-      // 转义 JSON 中的特殊字符用于 PowerShell
-      const authTokenEscaped = authToken.replace(/'/g, "''");
-      const clientInfoEscaped = clientInfo.replace(/'/g, "''");
+      // 使用 .NET 方法写入无 BOM 的 UTF-8 文件，避免编码问题
+      const authTokenEscaped = authToken.replace(/`/g, '``').replace(/\$/g, '`$');
+      const clientInfoEscaped = clientInfo.replace(/`/g, '``').replace(/\$/g, '`$');
       
       command = `$ssoDir = "$env:USERPROFILE\\.aws\\sso\\cache"
 if (!(Test-Path $ssoDir)) { New-Item -ItemType Directory -Force -Path $ssoDir | Out-Null }
-@'
+$utf8NoBom = New-Object System.Text.UTF8Encoding $false
+$authToken = @"
 ${authTokenEscaped}
-'@ | Out-File -FilePath "$ssoDir\\kiro-auth-token.json" -Encoding UTF8 -NoNewline
-@'
+"@
+$clientInfo = @"
 ${clientInfoEscaped}
-'@ | Out-File -FilePath "$ssoDir\\${clientIdHash}.json" -Encoding UTF8 -NoNewline
-Write-Host "已同步至 Kiro IDE" -ForegroundColor Green`;
+"@
+[System.IO.File]::WriteAllText("$ssoDir\\kiro-auth-token.json", $authToken, $utf8NoBom)
+[System.IO.File]::WriteAllText("$ssoDir\\${clientIdHash}.json", $clientInfo, $utf8NoBom)
+Write-Host "已同步至 Kiro IDE (UTF-8 无 BOM)" -ForegroundColor Green`;
       terminalName = 'PowerShell';
     } else {
       // macOS / Linux bash 命令


### PR DESCRIPTION
## 问题

修复 #1 - Kiro 同步后 IDE 仍提示未登录

## 原因分析

PowerShell 的 `Out-File -Encoding UTF8` 实际上会写入带 BOM 的 UTF-8 文件，某些程序（包括 Kiro IDE）可能无法正确读取带 BOM 的文件。

## 修复方案

使用 .NET 的 `System.Text.UTF8Encoding` 类，明确指定写入无 BOM 的 UTF-8 文件：

```powershell
$utf8NoBom = New-Object System.Text.UTF8Encoding $false
[System.IO.File]::WriteAllText($path, $content, $utf8NoBom)
```

## 测试

请在 Windows 系统上测试：
1. 注册一个账号并获取 Token
2. 点击 Kiro 按钮同步
3. 在 PowerShell 中执行复制的命令
4. 重启 Kiro IDE 检查是否正常登录